### PR TITLE
PEM-8539: Go sec fix

### DIFF
--- a/maasclient/client.go
+++ b/maasclient/client.go
@@ -251,7 +251,7 @@ func (m *authenticatedClientSet) VMHosts() VMHosts {
 
 func NewAuthenticatedClientSet(maasEndpoint, apiKey string, options ...func(client *authenticatedClientSet)) ClientSetInterface {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 : already addressed in PCP-3389
 		Proxy:           http.ProxyFromEnvironment,
 	}
 

--- a/maasclient/oauth1/oauth1.go
+++ b/maasclient/oauth1/oauth1.go
@@ -2,14 +2,15 @@ package oauth1
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505
 	"encoding/base64"
 	"fmt"
-	guuid "github.com/google/uuid"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	guuid "github.com/google/uuid"
 )
 
 type OAuth struct {


### PR DESCRIPTION
Fixes done:
G402: Silenced TLS InsecureSkipVerify with //nosec (already addressed in [PCP-3389](https://spectrocloud.atlassian.net/browse/PCP-3389))
G505: Silenced crypto/sha1 import with //nosec

[PCP-3389]: https://spectrocloud.atlassian.net/browse/PCP-3389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ