### PR TITLE
PCP-6452:  send all tags during machine allocation

### DIFF
--- a/maasclient/machine.go
+++ b/maasclient/machine.go
@@ -120,7 +120,7 @@ type machines struct {
 
 func (m *machines) WithTags(tags []string) MachineAllocator {
 	for _, tag := range tags {
-		m.params.Set(TagKey, tag)
+		m.params.Add(TagKey, tag)
 	}
 	return m
 }


### PR DESCRIPTION
## Summary
- `WithTags` was calling `params.Set` in a loop, which overwrites the value on each iteration — only the last tag was ever sent to the MAAS API
- Switched to `params.Add` so all tags are appended as repeated query parameters (`tags=a&tags=b&tags=c`), which is what the MAAS allocation API expects

## Test plan
- [ ] Verify that allocating a machine with multiple tags sends all tags in the request
- [ ] Verify that allocating with a single tag still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)