### PR TITLE
PCP-6452 : send all tags during allocation and fix OAuth signing for multi-valued params 

### DIFF
--- a/maasclient/client.go
+++ b/maasclient/client.go
@@ -323,7 +323,7 @@ func authHeader(req *http.Request, queryParams url.Values, apiKey string) string
 	if req.Method != http.MethodPut {
 		// for some bizarre-reason PUT doesn't need this
 		for k, v := range queryParams {
-			params[k] = v[0]
+			params[k] = v[len(v)-1]
 		}
 	}
 

--- a/maasclient/client_test.go
+++ b/maasclient/client_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 Spectro Cloud
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maasclient
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthHeader_ReturnsEmptyForInvalidKey(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/api/2.0/machines/", nil)
+	result := authHeader(req, url.Values{}, "invalid-key")
+	assert.Empty(t, result)
+}
+
+func TestAuthHeader_ValidOAuthFormat(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/api/2.0/machines/", nil)
+	result := authHeader(req, url.Values{"op": []string{"allocate"}}, "consumer:token:secret")
+	assert.True(t, strings.HasPrefix(result, "OAuth "), "auth header should start with 'OAuth '")
+}
+
+func TestAuthHeader_MultiValuedParams(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/api/2.0/machines/", nil)
+	params := url.Values{}
+	params.Add("tags", "prod")
+	params.Add("tags", "virtual")
+
+	assert.NotPanics(t, func() {
+		result := authHeader(req, params, "consumer:token:secret")
+		assert.True(t, strings.HasPrefix(result, "OAuth "), "auth header should be valid with multi-valued params")
+	})
+}
+
+func TestAuthHeader_PutMethodIgnoresParams(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPut, "http://example.com/api/2.0/machines/abc/", nil)
+	params := url.Values{}
+	params.Add("tags", "tag1")
+	params.Add("tags", "tag2")
+
+	result := authHeader(req, params, "consumer:token:secret")
+	assert.True(t, strings.HasPrefix(result, "OAuth "), "PUT should produce valid OAuth header")
+}

--- a/maasclient/machine.go
+++ b/maasclient/machine.go
@@ -120,7 +120,7 @@ type machines struct {
 
 func (m *machines) WithTags(tags []string) MachineAllocator {
 	for _, tag := range tags {
-		m.params.Set(TagKey, tag)
+		m.params.Add(TagKey, tag)
 	}
 	return m
 }

--- a/maasclient/machine_test.go
+++ b/maasclient/machine_test.go
@@ -159,3 +159,42 @@ func TestClient_UpdateMachine(t *testing.T) {
 	assert.Equal(t, res.SwapSize(), 10)
 
 }
+
+func TestWithTags_AllTagsPresentInParams(t *testing.T) {
+	m := &machines{Controller{
+		apiPath: "/machines/",
+		params:  ParamsBuilder(),
+	}}
+
+	tags := []string{"tag1", "tag2", "tag3"}
+	m.WithTags(tags)
+
+	got := m.params.Values()[TagKey]
+	assert.Len(t, got, 3, "all tags should be present in params")
+	assert.ElementsMatch(t, tags, got)
+}
+
+func TestWithTags_SingleTag(t *testing.T) {
+	m := &machines{Controller{
+		apiPath: "/machines/",
+		params:  ParamsBuilder(),
+	}}
+
+	m.WithTags([]string{"only-tag"})
+
+	got := m.params.Values()[TagKey]
+	assert.Len(t, got, 1)
+	assert.Equal(t, "only-tag", got[0])
+}
+
+func TestWithTags_Empty(t *testing.T) {
+	m := &machines{Controller{
+		apiPath: "/machines/",
+		params:  ParamsBuilder(),
+	}}
+
+	m.WithTags([]string{})
+
+	got := m.params.Values()[TagKey]
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
## Summary
- `WithTags` was calling `params.Set` in a loop, overwriting on each iteration — only the last tag was sent to the MAAS API. Switched to `params.Add` so all tags are sent as repeated query parameters (`tags=a&tags=b`)
- OAuth signing was using `v[0]` for multi-valued params. MAAS OAuth verification uses Python dict semantics (last value wins), so signing with `v[0]` caused 401 errors when multiple tags were present. Fixed to use `v[len(v)-1]`

## Test plan
- [ ] Verify that allocating a machine with multiple tags sends all tags in the request
- [ ] Verify no 401 errors when allocating with multiple tags
- [ ] Verify single tag allocation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)