### PR TITLE
feat: add node_devices, batch tagging methods; generalize tests; address lint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MAAS_ENDPOINT=http://your-maas-host:5240/MAAS
+MAAS_API_KEY=consumer_key:token_key:token_secret

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build
 .vscode
 /vendor
 .env
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build
 .idea
 .vscode
 /vendor
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ _build
 .vscode
 /vendor
 .env
+!.env.example
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:  ## Lint your code
 dev-lint:  ## Lint your code, dev-mode
 	golangci-lint run ./... --timeout 10m '--tests=false' '--disable=unused'
 
-test:  ## Run unit tests
+test:  ## Run unit and integration tests
 	@mkdir -p $(COVER_DIR)
 	rm -f $(COVER_DIR)/*.out
 	go test -v -covermode=count -coverprofile=$(COVER_DIR)/pkg_unit.out ./...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,55 @@
 # maas-client-go
-MAAS client for GO
 
-Usage
+MAAS client for Go.
+
+## Development
+
+### Prerequisites
+
+- Go 1.24
+- Make
+- Golangci-lint
+
+### Setup
+
+```bash
+make env
+```
+## Testing
+
+Set `MAAS_ENDPOINT` and `MAAS_API_KEY` in your environment.
+
+```bash
+export MAAS_ENDPOINT="http://10.0.0.1:5240/MAAS"
+export MAAS_API_KEY="abc123:def456:ghi789"
+```
+
+`make test` runs the full test suite. `MAAS_ENDPOINT` and `MAAS_API_KEY` must be set.
+
+Optional variables for integration tests that need environment-specific data:
+
+| Variable | Used by | Description |
+|----------|---------|-------------|
+| `MAAS_TEST_DNS_DOMAIN` | DNS tests | DNS domain for create/delete tests (e.g. `maas`). Defaults to the first domain returned by MAAS. |
+| `MAAS_TEST_DNS_FQDN` | DNS tests | Existing DNS record to use for FQDN filter tests. Defaults to the first listed resource. |
+| `MAAS_TEST_BOOT_RESOURCE_FILE` | Boot resource import test | Local path to a boot resource archive. Test is skipped when unset or the file does not exist. |
+| `MAAS_TEST_BOOT_RESOURCE_ID` | Boot resource get-by-id test | Boot resource ID to fetch. Defaults to the first resource from list. |
+| `MAAS_TEST_BOOT_RESOURCE_NAME` | Boot resource import test | Name for the imported resource. Defaults to a unique generated name. |
+| `MAAS_TEST_BOOT_RESOURCE_ARCH` | Boot resource import test | Architecture for the import. Defaults to `amd64/generic`. |
+| `MAAS_TEST_MACHINE_SYSTEM_ID` | Machine tests | Machine to use. Defaults to the first machine from list. |
+| `MAAS_TEST_MACHINE_ZONE` | Machine allocate test | Zone for allocation. Defaults to the first zone from list. |
+| `MAAS_TEST_ALLOW_MACHINE_MUTATIONS` | Machine allocate/deploy/update tests | Set to `1` to enable tests that allocate, deploy, or modify machines. |
+| `MAAS_TEST_DISTRO_SERIES` | Machine deploy test | Distro series to deploy. Required when machine mutations are enabled. |
+
+Some integration tests also assume specific data in your MAAS environment (hardcoded machine system IDs, zones, boot resources, and so on). Those may fail even with valid credentials unless your cluster matches the test fixtures.
+
+A small set of tests use `httptest` and run offline with no MAAS instance:
+
+```bash
+go test ./maasclient -run 'TestAuthHeader|TestWithTags|TestTagsAssignToMachines|TestNodeDevicesList'
+```
+
+## Usage
 
 ```
 	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 MAAS client for Go.
 
+## Usage
+
+```
+	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
+
+	ctx := context.Background()
+
+	// List DNS Resources
+	res, err := c.DNSResources().List(ctx, nil)
+
+
+
+	// List DNS Resources filtered by fqdn
+	filters := ParamsBuilder().Add(FQDNKey, "bad-doesntexist.maas")
+	res, err := c.DNSResources().List(ctx, filters)
+
+
+
+	// Create DNS Resource
+	res, err := c.DNSResources().
+		Builder().
+		WithFQDN("test-unit1.maas.sc").
+		WithAddressTTL("10").Create(ctx)
+
+
+	// Update DNS Resource
+	err = res.Modifier().
+		SetIPAddresses([]string{"1.2.3.4", "5.6.7.8"}).
+		Modify(ctx)
+
+
+	// Get DNS Resource by ID
+	res2 := c.DNSResources().DNSResource(res.ID())
+
+
+	// Delete DNS Resource
+	err = res.Delete(ctx)
+
+```
+
 ## Development
 
 ### Prerequisites
@@ -47,44 +87,4 @@ A small set of tests use `httptest` and run offline with no MAAS instance:
 
 ```bash
 go test ./maasclient -run 'TestAuthHeader|TestWithTags|TestTagsAssignToMachines|TestNodeDevicesList'
-```
-
-## Usage
-
-```
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
-	ctx := context.Background()
-
-	// List DNS Resources
-	res, err := c.DNSResources().List(ctx, nil)
-
-
-
-	// List DNS Resources filtered by fqdn
-	filters := ParamsBuilder().Add(FQDNKey, "bad-doesntexist.maas")
-	res, err := c.DNSResources().List(ctx, filters)
-
-
-
-	// Create DNS Resource
-	res, err := c.DNSResources().
-		Builder().
-		WithFQDN("test-unit1.maas.sc").
-		WithAddressTTL("10").Create(ctx)
-
-
-	// Update DNS Resource
-	err = res.Modifier().
-		SetIPAddresses([]string{"1.2.3.4", "5.6.7.8"}).
-		Modify(ctx)
-
-
-	// Get DNS Resource by ID
-	res2 := c.DNSResources().DNSResource(res.ID())
-
-
-	// Delete DNS Resource
-	err = res.Delete(ctx)
-
 ```

--- a/maasclient/bootresource.go
+++ b/maasclient/bootresource.go
@@ -131,7 +131,7 @@ func (brs *bootResources) Create(ctx context.Context) (BootResource, error) {
 	if err != nil {
 		return nil, err
 	}
-	writer.Close()
+	_ = writer.Close()
 
 	res, err := brs.client.PostForm(ctx, brs.apiPath, writer.FormDataContentType(), brs.params.Values(), buf)
 	if err != nil {
@@ -221,7 +221,7 @@ func (b *bootResource) Upload(ctx context.Context) error {
 		return err
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	reader := bufio.NewReader(f)
 	fileBuf := make([]byte, 1<<22)
@@ -359,7 +359,7 @@ func writeMultiPartParams(writer *multipart.Writer, params url.Values) error {
 				return err
 			}
 			buffer := bytes.NewBufferString(value)
-			io.Copy(fw, buffer)
+			_, _ = io.Copy(fw, buffer)
 		}
 	}
 	return nil

--- a/maasclient/bootresource_test.go
+++ b/maasclient/bootresource_test.go
@@ -18,14 +18,18 @@ package maasclient
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
+	"crypto/sha256"
+	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetBootResources(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
+	c := requireMAASIntegration(t)
 	ctx := context.Background()
 
 	t.Run("list-all", func(t *testing.T) {
@@ -33,21 +37,85 @@ func TestGetBootResources(t *testing.T) {
 		assert.Nil(t, err, "expecting nil error")
 		assert.NotEmpty(t, list)
 	})
-	//
-	t.Run("list-by-id", func(t *testing.T) {
-		res, err := c.BootResources().BootResource(7).Get(ctx)
+
+	t.Run("get-by-id", func(t *testing.T) {
+		list, err := c.BootResources().List(ctx, nil)
+		assert.Nil(t, err)
+		if len(list) == 0 {
+			t.Skip("no boot resources in this MAAS environment")
+		}
+
+		id := list[0].ID()
+		if envID := os.Getenv("MAAS_TEST_BOOT_RESOURCE_ID"); envID != "" {
+			parsed, parseErr := strconv.Atoi(envID)
+			assert.Nil(t, parseErr)
+			id = parsed
+		}
+
+		res, err := c.BootResources().BootResource(id).Get(ctx)
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 	})
 
 	t.Run("import image", func(t *testing.T) {
-		res, err := c.BootResources().Builder("test-image",
-			"amd64/generic",
-			"e9844638c7345d182c5d88e1eaeae74749d02beeca38587a530207fddc0a280a",
-			"/Users/deepak/maas/ubuntu.tar.gz", 1262032476).Create(ctx)
+		filePath := os.Getenv("MAAS_TEST_BOOT_RESOURCE_FILE")
+		if filePath == "" {
+			t.Skip("MAAS_TEST_BOOT_RESOURCE_FILE is not set")
+		}
+
+		info, err := os.Stat(filePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				t.Skipf("boot resource file not found: %s", filePath)
+			}
+			t.Fatalf("stat boot resource file: %v", err)
+		}
+
+		hash, err := sha256File(filePath)
 		assert.Nil(t, err)
+
+		name := os.Getenv("MAAS_TEST_BOOT_RESOURCE_NAME")
+		if name == "" {
+			name = uniqueDNSResourceName("maas-client-go-boot")
+		}
+
+		architecture := os.Getenv("MAAS_TEST_BOOT_RESOURCE_ARCH")
+		if architecture == "" {
+			architecture = "amd64/generic"
+		}
+
+		res, err := c.BootResources().Builder(
+			name,
+			architecture,
+			hash,
+			filePath,
+			int(info.Size()),
+		).Create(ctx)
+		assert.Nil(t, err)
+		if res == nil {
+			t.Fatal("expected boot resource after create")
+		}
+		t.Cleanup(func() {
+			_ = res.Delete(ctx)
+		})
+
 		err = res.Upload(ctx)
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 	})
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }

--- a/maasclient/bootresource_test.go
+++ b/maasclient/bootresource_test.go
@@ -110,7 +110,7 @@ func sha256File(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/maasclient/client.go
+++ b/maasclient/client.go
@@ -195,6 +195,7 @@ type authenticatedClientSet struct {
 	subnetsController           Subnets
 	machineController           Machines
 	networkInterfacesController NetworkInterfaces
+	nodeDevicesController       NodeDevices
 	ipAddressesController       IPAddresses
 	vmHostsController           VMHosts
 	ipRangesController          IPRanges
@@ -252,6 +253,10 @@ func (m *authenticatedClientSet) NetworkInterfaces() NetworkInterfaces {
 	return m.networkInterfacesController
 }
 
+func (m *authenticatedClientSet) NodeDevices() NodeDevices {
+	return m.nodeDevicesController
+}
+
 func (m *authenticatedClientSet) IPAddresses() IPAddresses {
 	return m.ipAddressesController
 }
@@ -299,6 +304,7 @@ func NewAuthenticatedClientSet(maasEndpoint, apiKey string, options ...func(clie
 	clientSet.subnetsController = NewSubnetsClient(client)
 	clientSet.machineController = NewMachinesClient(client)
 	clientSet.networkInterfacesController = NewNetworkInterfacesClient(client)
+	clientSet.nodeDevicesController = NewNodeDevicesClient(client)
 	clientSet.ipAddressesController = NewIPAddressesClient(client)
 	clientSet.vmHostsController = NewVMHostsClient(client)
 	clientSet.ipRangesController = NewIPRangesClient(client)

--- a/maasclient/clientset.go
+++ b/maasclient/clientset.go
@@ -24,6 +24,7 @@ type ClientSetInterface interface {
 	Tags() Tags
 	Machines() Machines
 	NetworkInterfaces() NetworkInterfaces
+	NodeDevices() NodeDevices
 	RackControllers() RackControllers
 	ResourcePools() ResourcePools
 	Spaces() Spaces

--- a/maasclient/common.go
+++ b/maasclient/common.go
@@ -19,7 +19,7 @@ package maasclient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -30,9 +30,9 @@ type Controller struct {
 }
 
 func unMarshalJson(res *http.Response, v interface{}) error {
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/maasclient/constants.go
+++ b/maasclient/constants.go
@@ -19,7 +19,7 @@ package maasclient
 type FilterType string
 
 const (
-	// parametes
+	// parameters
 	FQDNKey            = "fqdn"
 	DomainKey          = "domain"
 	NameKey            = "name"
@@ -63,11 +63,28 @@ const (
 	ParentKey          = "parent"
 	EphemeralDeployKey = "ephemeral_deploy"
 
+	// Node device filters (GET /nodes/{system_id}/devices/)
+	BusKey                 = "bus"
+	HardwareTypeKey        = "hardware_type"
+	VendorIDKey            = "vendor_id"
+	ProductIDKey           = "product_id"
+	VendorNameKey          = "vendor_name"
+	ProductNameKey         = "product_name"
+	CommissioningDriverKey = "commissioning_driver"
+
+	// Node device hardware_type filter values
+	HardwareTypeNode    = "node"
+	HardwareTypeCPU     = "cpu"
+	HardwareTypeMemory  = "memory"
+	HardwareTypeStorage = "storage"
+	HardwareTypeNetwork = "network"
+	HardwareTypeGPU     = "gpu"
+
 	// Network interface modes for link_subnet (MAAS API: AUTO, DHCP, STATIC, LINK_UP).
 	// Use lowercase to match existing API usage. See https://maas.io/docs/interfaces
-	ModeAuto   = "auto"   // MAAS assigns static IP from managed subnet at deploy; no DHCP on wire (avoids DHCP-provided routes)
-	ModeDHCP   = "dhcp"   // Interface uses DHCP on the subnet
-	ModeStatic = "static" // Static IP (provide ip_address or MAAS auto-selects from subnet)
+	ModeAuto   = "auto"    // MAAS assigns static IP from managed subnet at deploy; no DHCP on wire (avoids DHCP-provided routes)
+	ModeDHCP   = "dhcp"    // Interface uses DHCP on the subnet
+	ModeStatic = "static"  // Static IP (provide ip_address or MAAS auto-selects from subnet)
 	ModeLinkUp = "link_up" // Bring interface up on subnet with no IP
 
 	// Resource operations

--- a/maasclient/dns.go
+++ b/maasclient/dns.go
@@ -139,6 +139,9 @@ func (d *dnsResource) FQDN() string {
 }
 
 func (d *dnsResource) AddressTTL() int {
+	if d.addressTTL == nil {
+		return 0
+	}
 	return *d.addressTTL
 }
 

--- a/maasclient/dns_test.go
+++ b/maasclient/dns_test.go
@@ -18,16 +18,15 @@ package maasclient
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDNSResources(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
+	c := requireMAASIntegration(t)
 	ctx := context.Background()
+	domain := testDNSDomain(t, c, ctx)
 
 	t.Run("no-options", func(t *testing.T) {
 		res, err := c.DNSResources().List(ctx, nil)
@@ -40,56 +39,52 @@ func TestGetDNSResources(t *testing.T) {
 		assert.NotEmpty(t, res[0].FQDN())
 	})
 
-	t.Run("invalid-search", func(t *testing.T) {
-		filters := ParamsBuilder().Add(FQDNKey, "bad-doesntexist.maas")
+	t.Run("search nonexistent fqdn", func(t *testing.T) {
+		nonexistent := dnsFQDN(uniqueDNSResourceName("nonexistent"), domain)
+		filters := ParamsBuilder().Add(FQDNKey, nonexistent)
 		res, err := c.DNSResources().List(ctx, filters)
-		assert.NotNil(t, err, "expecting nil error")
-		assert.Nil(t, res, "expecting non-nil result")
+		assert.Nil(t, err)
 		assert.Empty(t, res)
 	})
 
-	t.Run("get maas-1.maas", func(t *testing.T) {
-		filters := ParamsBuilder().Add(FQDNKey, "maas-1.maas.sc")
+	t.Run("get by fqdn", func(t *testing.T) {
+		existingFQDN := discoverDNSResourceFQDN(t, c, ctx)
+
+		filters := ParamsBuilder().Add(FQDNKey, existingFQDN)
 		res, err := c.DNSResources().List(ctx, filters)
 		assert.Nil(t, err, "expecting nil error")
 		assert.NotEmpty(t, res)
-		assert.NotZero(t, res[0].AddressTTL())
-		assert.NotEmpty(t, res[0].IPAddresses())
-		assert.NotEmpty(t, res[0].IPAddresses()[0].IP())
-
-		// TODO create test DNS
-
+		assert.Equal(t, existingFQDN, res[0].FQDN())
 	})
 
-	t.Run("create test-unit-1.maas", func(t *testing.T) {
+	t.Run("create and delete", func(t *testing.T) {
+		testFQDN := dnsFQDN(uniqueDNSResourceName("maas-client-go"), domain)
+
 		res, err := c.DNSResources().
 			Builder().
-			WithFQDN("test-unit-1.maas.sc").
+			WithFQDN(testFQDN).
 			WithAddressTTL("10").Create(ctx)
 		assert.Nil(t, err, "expecting nil error")
 		assert.NotNil(t, res)
-		assert.Equal(t, res.FQDN(), "test-unit-1.maas.sc")
-		assert.Equal(t, res.AddressTTL(), 10)
+		assert.Equal(t, testFQDN, res.FQDN())
+		assert.Equal(t, 10, res.AddressTTL())
 		assert.Empty(t, res.IPAddresses())
 
 		err = res.Delete(ctx)
 		assert.Nil(t, err, "expecting nil error")
-
 	})
 
-	t.Run("create test-unit-2.maas", func(t *testing.T) {
-
-		//err := c.DNSResources().DNSResource(148).Delete(ctx)
-		//assert.Nil(t, err)
+	t.Run("create modify and delete", func(t *testing.T) {
+		testFQDN := dnsFQDN(uniqueDNSResourceName("maas-client-go"), domain)
 
 		res, err := c.DNSResources().
 			Builder().
-			WithFQDN("test-unit-2.maas.sc").
+			WithFQDN(testFQDN).
 			WithAddressTTL("10").Create(ctx)
 		assert.Nil(t, err, "expecting nil error")
 		assert.NotNil(t, res)
-		assert.Equal(t, res.FQDN(), "test-unit-2.maas.sc")
-		assert.Equal(t, res.AddressTTL(), 10)
+		assert.Equal(t, testFQDN, res.FQDN())
+		assert.Equal(t, 10, res.AddressTTL())
 		assert.Empty(t, res.IPAddresses())
 
 		res, err = res.Modifier().
@@ -98,24 +93,15 @@ func TestGetDNSResources(t *testing.T) {
 		if err != nil {
 			t.Fatal("error", err)
 		}
-		assert.Equal(t, res.FQDN(), "test-unit-2.maas.sc")
-		assert.Equal(t, res.AddressTTL(), 10)
+		assert.Equal(t, testFQDN, res.FQDN())
+		assert.Equal(t, 10, res.AddressTTL())
 		assert.NotEmpty(t, res.IPAddresses())
 
 		res2, err := c.DNSResources().DNSResource(res.ID()).Get(ctx)
 		assert.Nil(t, err)
-		assert.True(t, len(res2.IPAddresses()) == 2)
+		assert.Len(t, res2.IPAddresses(), 2)
 
 		err = res.Delete(ctx)
 		assert.Nil(t, err, "expecting nil error")
-
 	})
-
-	//assert.Equal(t, 1, res.Count, "expecting 1 resource")
-
-	//assert.Equal(t, 1, res.PagesCount, "expecting 1 PAGE found")
-	//
-	//assert.Equal(t, "integration_face_id", res.Faces[0].FaceID, "expecting correct face_id")
-	//assert.NotEmpty(t, res.Faces[0].FaceToken, "expecting non-empty face_token")
-	//assert.Greater(t, len(res.Faces[0].FaceImages), 0, "expecting non-empty face_images")
 }

--- a/maasclient/integration_helpers_test.go
+++ b/maasclient/integration_helpers_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 Spectro Cloud
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maasclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// requireMAASIntegration skips the test when MAAS_ENDPOINT or MAAS_API_KEY is unset.
+func requireMAASIntegration(t *testing.T) ClientSetInterface {
+	t.Helper()
+
+	endPoint := os.Getenv("MAAS_ENDPOINT")
+	apiKey := os.Getenv("MAAS_API_KEY")
+	if endPoint == "" || apiKey == "" {
+		t.Skip("MAAS_ENDPOINT and MAAS_API_KEY must be set for integration tests")
+	}
+
+	return NewAuthenticatedClientSet(endPoint, apiKey)
+}
+
+// testDNSDomain returns the DNS domain to use in integration tests.
+// It prefers MAAS_TEST_DNS_DOMAIN; otherwise it uses the first domain from MAAS.
+func testDNSDomain(t *testing.T, c ClientSetInterface, ctx context.Context) string {
+	t.Helper()
+
+	if domain := os.Getenv("MAAS_TEST_DNS_DOMAIN"); domain != "" {
+		return domain
+	}
+
+	domains, err := c.Domains().List(ctx)
+	if err != nil {
+		t.Fatalf("list domains: %v", err)
+	}
+	for _, d := range domains {
+		if name := d.Name(); name != "" {
+			return name
+		}
+	}
+
+	t.Skip("no DNS domain found in MAAS; set MAAS_TEST_DNS_DOMAIN")
+	return ""
+}
+
+// discoverDNSResourceFQDN returns an existing DNS resource FQDN for read-only tests.
+// It prefers MAAS_TEST_DNS_FQDN; otherwise it uses the first listed resource.
+func discoverDNSResourceFQDN(t *testing.T, c ClientSetInterface, ctx context.Context) string {
+	t.Helper()
+
+	if fqdn := os.Getenv("MAAS_TEST_DNS_FQDN"); fqdn != "" {
+		return fqdn
+	}
+
+	resources, err := c.DNSResources().List(ctx, nil)
+	if err != nil {
+		t.Fatalf("list dns resources: %v", err)
+	}
+	for _, r := range resources {
+		if fqdn := r.FQDN(); fqdn != "" {
+			return fqdn
+		}
+	}
+
+	t.Skip("no DNS resources found; set MAAS_TEST_DNS_FQDN")
+	return ""
+}
+
+func uniqueDNSResourceName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+func dnsFQDN(name, domain string) string {
+	return name + "." + domain
+}
+
+// discoverMachineSystemID returns a machine system ID for read-only integration tests.
+// It prefers MAAS_TEST_MACHINE_SYSTEM_ID; otherwise it uses the first listed machine.
+func discoverMachineSystemID(t *testing.T, c ClientSetInterface, ctx context.Context) string {
+	t.Helper()
+
+	if systemID := os.Getenv("MAAS_TEST_MACHINE_SYSTEM_ID"); systemID != "" {
+		return systemID
+	}
+
+	machines, err := c.Machines().List(ctx, nil)
+	if err != nil {
+		t.Fatalf("list machines: %v", err)
+	}
+	for _, m := range machines {
+		if systemID := m.SystemID(); systemID != "" {
+			return systemID
+		}
+	}
+
+	t.Skip("no machines found; set MAAS_TEST_MACHINE_SYSTEM_ID")
+	return ""
+}
+
+// discoverTestZone returns a zone name for integration tests.
+// It prefers MAAS_TEST_MACHINE_ZONE; otherwise it uses the first zone from MAAS.
+func discoverTestZone(t *testing.T, c ClientSetInterface, ctx context.Context) string {
+	t.Helper()
+
+	if zone := os.Getenv("MAAS_TEST_MACHINE_ZONE"); zone != "" {
+		return zone
+	}
+
+	zones, err := c.Zones().List(ctx)
+	if err != nil {
+		t.Fatalf("list zones: %v", err)
+	}
+	for _, z := range zones {
+		if name := z.Name(); name != "" {
+			return name
+		}
+	}
+
+	t.Skip("no zones found; set MAAS_TEST_MACHINE_ZONE")
+	return ""
+}
+
+// requireMachineMutations skips tests that allocate, deploy, or update machines.
+func requireMachineMutations(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("MAAS_TEST_ALLOW_MACHINE_MUTATIONS") != "1" {
+		t.Skip("machine mutation tests disabled; set MAAS_TEST_ALLOW_MACHINE_MUTATIONS=1 to enable")
+	}
+}

--- a/maasclient/ipranges.go
+++ b/maasclient/ipranges.go
@@ -47,11 +47,11 @@ type ipRange struct {
 	subnet  *subnet
 }
 
-func (r *ipRange) ID() int          { return r.id }
-func (r *ipRange) Type() string     { return r.typ }
-func (r *ipRange) StartIP() string  { return r.startIP }
-func (r *ipRange) EndIP() string    { return r.endIP }
-func (r *ipRange) Comment() string  { return r.comment }
+func (r *ipRange) ID() int         { return r.id }
+func (r *ipRange) Type() string    { return r.typ }
+func (r *ipRange) StartIP() string { return r.startIP }
+func (r *ipRange) EndIP() string   { return r.endIP }
+func (r *ipRange) Comment() string { return r.comment }
 func (r *ipRange) Subnet() Subnet {
 	if r.subnet == nil {
 		return nil

--- a/maasclient/machine.go
+++ b/maasclient/machine.go
@@ -67,6 +67,12 @@ type Machine interface {
 	Tags() []string
 	// Parent returns the parent system_id when power_type is "lxd", or empty string otherwise
 	Parent() string
+	// CPUCount returns the number of CPU cores on the machine
+	CPUCount() int
+	// Memory returns the machine memory in MB
+	Memory() int
+	// Architecture returns the machine architecture (e.g., "amd64/generic")
+	Architecture() string
 }
 
 type PowerManagerOn interface {
@@ -185,7 +191,10 @@ func (m *machines) WithNotPodType(podType string) MachineAllocator {
 }
 
 func (m *machines) List(ctx context.Context, params Params) ([]Machine, error) {
-	res, err := m.client.Get(ctx, m.apiPath, m.params.Values())
+	if params == nil {
+		params = m.params
+	}
+	res, err := m.client.Get(ctx, m.apiPath, params.Values())
 	if err != nil {
 		return nil, err
 	}
@@ -252,6 +261,8 @@ type machine struct {
 	bootInterfaceType string   // Type of boot interface (physical, bridge, bond, etc.)
 	bootInterfaceName string   // Name of boot interface (e.g., enp2s0)
 	memory            int      // Memory in MB
+	cpuCount          int      // Number of CPU cores
+	architecture      string   // Machine architecture (e.g., amd64/generic)
 	storageMBDecimal  float64  // Total storage in decimal MB as reported by MAAS (e.g., 250059.35)
 	tags              []string // Tag names applied to the machine (if provided by MAAS)
 	parentSystemID    string   // Parent system_id for LXD VMs
@@ -509,6 +520,21 @@ func (m *machine) Parent() string {
 	return ""
 }
 
+// CPUCount returns the number of CPU cores on the machine
+func (m *machine) CPUCount() int {
+	return m.cpuCount
+}
+
+// Memory returns the machine memory in MB
+func (m *machine) Memory() int {
+	return m.memory
+}
+
+// Architecture returns the machine architecture (e.g., "amd64/generic")
+func (m *machine) Architecture() string {
+	return m.architecture
+}
+
 func (m *machine) UnmarshalJSON(data []byte) error {
 	des := &struct {
 		SystemID      string        `json:"system_id"`
@@ -524,6 +550,8 @@ func (m *machine) UnmarshalJSON(data []byte) error {
 		DistroSeries  string        `json:"distro_series"`
 		SwapSize      int           `json:"swap_size"`
 		Memory        int           `json:"memory"`
+		CPUCount      int           `json:"cpu_count"`
+		Architecture  string        `json:"architecture"`
 		Storage       float64       `json:"storage"`
 		BootInterface struct {
 			ID       int      `json:"id"`
@@ -558,6 +586,8 @@ func (m *machine) UnmarshalJSON(data []byte) error {
 	m.distroSeries = des.DistroSeries
 	m.swapSize = des.SwapSize
 	m.memory = des.Memory
+	m.cpuCount = des.CPUCount
+	m.architecture = des.Architecture
 	m.storageMBDecimal = des.Storage
 	m.parentSystemID = des.Parent.SystemID
 

--- a/maasclient/machine_test.go
+++ b/maasclient/machine_test.go
@@ -18,12 +18,17 @@ package maasclient
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -33,52 +38,38 @@ func TestMain(m *testing.M) {
 }
 
 func TestClient_GetMachine(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
+	c := requireMAASIntegration(t)
 	ctx := context.Background()
-	res := c.Machines().Machine("e37xxm")
-	_, err := res.Get(ctx)
-	//.machine(ctx, "e37xxm")
+	systemID := discoverMachineSystemID(t, c, ctx)
 
-	assert.Nil(t, err, "expecting nil error")
+	res, err := c.Machines().Machine(systemID).Get(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
 
-	assert.NotNil(t, res, "expecting non-nil result")
-	assert.NotEmpty(t, res.SystemID())
+	assert.Equal(t, systemID, res.SystemID())
 	assert.NotEmpty(t, res.Hostname())
-	assert.Equal(t, res.State(), "Deployed")
+	assert.NotEmpty(t, res.State())
 	assert.NotEmpty(t, res.PowerState())
-	assert.Equal(t, res.Zone().Name(), "az2")
-
-	assert.NotEmpty(t, res.FQDN())
-	assert.NotEmpty(t, res.IPAddresses())
-
-	assert.NotEmpty(t, res.OSSystem())
-	assert.NotEmpty(t, res.DistroSeries())
-
-	assert.Zero(t, res.SwapSize())
-
 }
 
 func TestClient_AllocateMachine(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
+	requireMachineMutations(t)
+	c := requireMAASIntegration(t)
 	ctx := context.Background()
 
 	releaseMachine := func(res Machine) {
 		if res != nil {
 			_, err := res.Releaser().
-				WithComment("releaseaan").
+				WithComment("maas-client-go test release").
 				Release(ctx)
 			assert.Nil(t, err)
-			assert.NotNil(t, res)
 		}
 	}
 
 	t.Run("no-options", func(t *testing.T) {
 		res, err := c.Machines().Allocator().Allocate(ctx)
-
-		assert.Nil(t, err, "expecting nil error")
-		assert.NotNil(t, res)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 
 		releaseMachine(res)
 	})
@@ -89,31 +80,35 @@ func TestClient_AllocateMachine(t *testing.T) {
 			WithSystemID("abc").
 			Allocate(ctx)
 
-		assert.NotNil(t, err, "expecting error")
-
+		assert.Error(t, err)
 		releaseMachine(res)
 	})
 
-	t.Run("with-az", func(t *testing.T) {
-		res, err := c.Machines().Allocator().WithZone("az1").Allocate(ctx)
+	t.Run("with-zone", func(t *testing.T) {
+		zone := discoverTestZone(t, c, ctx)
 
-		assert.Nil(t, err, "expecting nil error")
-		assert.NotNil(t, res)
+		res, err := c.Machines().Allocator().WithZone(zone).Allocate(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 
 		releaseMachine(res)
 	})
-
 }
 
 func TestClient_DeployMachine(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
-
+	requireMachineMutations(t)
+	c := requireMAASIntegration(t)
 	ctx := context.Background()
+
+	distroSeries := os.Getenv("MAAS_TEST_DISTRO_SERIES")
+	if distroSeries == "" {
+		t.Skip("MAAS_TEST_DISTRO_SERIES must be set for deploy tests")
+	}
 
 	releaseMachine := func(res Machine) {
 		if res != nil {
 			_, err := res.Releaser().
-				WithComment("releaseaan a").
+				WithComment("maas-client-go test release").
 				Release(ctx)
 			assert.Nil(t, err)
 		}
@@ -121,43 +116,41 @@ func TestClient_DeployMachine(t *testing.T) {
 
 	t.Run("simple", func(t *testing.T) {
 		res, err := c.Machines().Allocator().Allocate(ctx)
-		if err != nil {
-			t.Fatal("Machine didn't allocate")
-		}
-		assert.NotNil(t, res)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 		assert.NotEmpty(t, res.SystemID())
 
 		res, err = res.Modifier().SetSwapSize(0).Update(ctx)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = res.Deployer().
 			SetOSSystem("custom").
-			SetDistroSeries("u-1804-0-k-11915-0").Deploy(ctx)
-		assert.Nil(t, err, "expecting nil error")
-		assert.NotNil(t, res)
+			SetDistroSeries(distroSeries).Deploy(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 
-		assert.Equal(t, res.OSSystem(), "custom")
-		assert.Equal(t, res.DistroSeries(), "u-1804-0-k-11915-0")
+		assert.Equal(t, "custom", res.OSSystem())
+		assert.Equal(t, distroSeries, res.DistroSeries())
 
-		// Give me a few seconds before clenaing up
 		time.Sleep(15 * time.Second)
 
 		releaseMachine(res)
 	})
-
 }
 
 func TestClient_UpdateMachine(t *testing.T) {
-	c := NewAuthenticatedClientSet(os.Getenv("MAAS_ENDPOINT"), os.Getenv("MAAS_API_KEY"))
+	requireMachineMutations(t)
+	c := requireMAASIntegration(t)
+	ctx := context.Background()
+	systemID := discoverMachineSystemID(t, c, ctx)
 
-	res, err := c.Machines().Machine("e37xxm").
+	res, err := c.Machines().Machine(systemID).
 		Modifier().
 		SetSwapSize(10).
-		Update(context.Background())
-	assert.Nil(t, err)
-	assert.NotNil(t, res)
-	assert.Equal(t, res.SwapSize(), 10)
-
+		Update(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 10, res.SwapSize())
 }
 
 func TestWithTags_AllTagsPresentInParams(t *testing.T) {
@@ -197,4 +190,88 @@ func TestWithTags_Empty(t *testing.T) {
 
 	got := m.params.Values()[TagKey]
 	assert.Empty(t, got)
+}
+
+const machinesListResponse = `[
+  {
+    "system_id": "abc123",
+    "hostname": "node-1",
+    "fqdn": "node-1.maas",
+    "status_name": "Ready",
+    "architecture": "amd64/generic",
+    "cpu_count": 8,
+    "memory": 16384,
+    "zone": {"id": 1, "name": "az1", "description": ""},
+    "pool": {"id": 0, "name": "default", "description": ""},
+    "tag_names": ["gpu", "team-a"]
+  }
+]`
+
+// Regression test: List used to ignore its params argument and always send
+// the controller's internal (empty) params, so filters such as tags never
+// reached the MAAS API.
+func TestMachinesList_PassesParams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("forwards caller params as query string", func(t *testing.T) {
+		var gotQuery url.Values
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, machinesListResponse)
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		params := ParamsBuilder().Add(TagKey, "gpu").Add(TagKey, "team-a")
+		machines, err := c.Machines().List(ctx, params)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"gpu", "team-a"}, gotQuery[TagKey])
+		assert.Len(t, machines, 1)
+	})
+
+	t.Run("nil params sends no query string", func(t *testing.T) {
+		var gotQuery string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, machinesListResponse)
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		machines, err := c.Machines().List(ctx, nil)
+		assert.Nil(t, err)
+		assert.Empty(t, gotQuery)
+		assert.Len(t, machines, 1)
+	})
+}
+
+func TestMachinesList_MachineFields(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, machinesListResponse)
+	}))
+	defer server.Close()
+
+	c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+	machines, err := c.Machines().List(ctx, nil)
+	assert.Nil(t, err)
+	assert.Len(t, machines, 1)
+
+	m := machines[0]
+	assert.Equal(t, "abc123", m.SystemID())
+	assert.Equal(t, "node-1", m.Hostname())
+	assert.Equal(t, "Ready", m.State())
+	assert.Equal(t, 8, m.CPUCount())
+	assert.Equal(t, 16384, m.Memory())
+	assert.Equal(t, "amd64/generic", m.Architecture())
+	assert.Equal(t, "az1", m.ZoneName())
+	assert.Equal(t, "default", m.ResourcePoolName())
+	assert.Equal(t, []string{"gpu", "team-a"}, m.Tags())
 }

--- a/maasclient/machine_test.go
+++ b/maasclient/machine_test.go
@@ -19,7 +19,6 @@ package maasclient
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,12 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestClient_GetMachine(t *testing.T) {
 	c := requireMAASIntegration(t)
@@ -218,7 +211,7 @@ func TestMachinesList_PassesParams(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotQuery = r.URL.Query()
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, machinesListResponse)
+			_, _ = fmt.Fprint(w, machinesListResponse)
 		}))
 		defer server.Close()
 
@@ -236,7 +229,7 @@ func TestMachinesList_PassesParams(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotQuery = r.URL.RawQuery
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, machinesListResponse)
+			_, _ = fmt.Fprint(w, machinesListResponse)
 		}))
 		defer server.Close()
 
@@ -254,7 +247,7 @@ func TestMachinesList_MachineFields(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, machinesListResponse)
+		_, _ = fmt.Fprint(w, machinesListResponse)
 	}))
 	defer server.Close()
 

--- a/maasclient/nodedevices.go
+++ b/maasclient/nodedevices.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2021 Spectro Cloud
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maasclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// NodeDevices provides methods to interact with devices discovered on a machine
+type NodeDevices interface {
+	// List retrieves devices for the machine identified by systemID.
+	// Optional params filter the result, e.g. HardwareTypeKey=HardwareTypeGPU
+	// to return only GPU devices, or BusKey, VendorIDKey, ProductIDKey,
+	// VendorNameKey, ProductNameKey, CommissioningDriverKey. A nil params
+	// returns all devices.
+	List(ctx context.Context, systemID string, params Params) ([]NodeDevice, error)
+}
+
+// NodeDevice represents a single device discovered on a machine during commissioning
+type NodeDevice interface {
+	ID() string
+	// BusName is the bus the device is attached to, e.g. "PCIE" or "USB"
+	BusName() string
+	// HardwareTypeName is the type of device, e.g. "node", "cpu", "memory", "storage", "network", "gpu"
+	HardwareTypeName() string
+	VendorID() string
+	ProductID() string
+	VendorName() string
+	ProductName() string
+	CommissioningDriver() string
+	BusNumber() int
+	DeviceNumber() int
+	PCIAddress() string
+	NUMANode() int
+	SystemID() string
+	ResourceUri() string
+}
+
+type nodeDevices struct {
+	Controller
+}
+
+func (nd *nodeDevices) List(ctx context.Context, systemID string, params Params) ([]NodeDevice, error) {
+	if params == nil {
+		params = ParamsBuilder()
+	}
+	path := fmt.Sprintf("/nodes/%s/devices/", systemID)
+	res, err := nd.client.Get(ctx, path, params.Values())
+	if err != nil {
+		return nil, err
+	}
+
+	var obj []*nodeDevice
+	err = unMarshalJson(res, &obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeDeviceSliceToInterface(obj), nil
+}
+
+type nodeDevice struct {
+	id                  string
+	busName             string
+	hardwareTypeName    string
+	vendorID            string
+	productID           string
+	vendorName          string
+	productName         string
+	commissioningDriver string
+	busNumber           int
+	deviceNumber        int
+	pciAddress          string
+	numaNode            int
+	systemID            string
+	resourceUri         string
+}
+
+func (d *nodeDevice) ID() string {
+	return d.id
+}
+
+func (d *nodeDevice) BusName() string {
+	return d.busName
+}
+
+func (d *nodeDevice) HardwareTypeName() string {
+	return d.hardwareTypeName
+}
+
+func (d *nodeDevice) VendorID() string {
+	return d.vendorID
+}
+
+func (d *nodeDevice) ProductID() string {
+	return d.productID
+}
+
+func (d *nodeDevice) VendorName() string {
+	return d.vendorName
+}
+
+func (d *nodeDevice) ProductName() string {
+	return d.productName
+}
+
+func (d *nodeDevice) CommissioningDriver() string {
+	return d.commissioningDriver
+}
+
+func (d *nodeDevice) BusNumber() int {
+	return d.busNumber
+}
+
+func (d *nodeDevice) DeviceNumber() int {
+	return d.deviceNumber
+}
+
+func (d *nodeDevice) PCIAddress() string {
+	return d.pciAddress
+}
+
+func (d *nodeDevice) NUMANode() int {
+	return d.numaNode
+}
+
+func (d *nodeDevice) SystemID() string {
+	return d.systemID
+}
+
+func (d *nodeDevice) ResourceUri() string {
+	return d.resourceUri
+}
+
+func (d *nodeDevice) UnmarshalJSON(data []byte) error {
+	des := struct {
+		ID                  int    `json:"id"`
+		BusName             string `json:"bus_name"`
+		HardwareTypeName    string `json:"hardware_type_name"`
+		VendorID            string `json:"vendor_id"`
+		ProductID           string `json:"product_id"`
+		VendorName          string `json:"vendor_name"`
+		ProductName         string `json:"product_name"`
+		CommissioningDriver string `json:"commissioning_driver"`
+		BusNumber           int    `json:"bus_number"`
+		DeviceNumber        int    `json:"device_number"`
+		PCIAddress          string `json:"pci_address"`
+		NUMANode            int    `json:"numa_node"`
+		SystemID            string `json:"system_id"`
+		ResourceUri         string `json:"resource_uri"`
+	}{}
+
+	err := json.Unmarshal(data, &des)
+	if err != nil {
+		return err
+	}
+
+	d.id = fmt.Sprintf("%d", des.ID)
+	d.busName = des.BusName
+	d.hardwareTypeName = des.HardwareTypeName
+	d.vendorID = des.VendorID
+	d.productID = des.ProductID
+	d.vendorName = des.VendorName
+	d.productName = des.ProductName
+	d.commissioningDriver = des.CommissioningDriver
+	d.busNumber = des.BusNumber
+	d.deviceNumber = des.DeviceNumber
+	d.pciAddress = des.PCIAddress
+	d.numaNode = des.NUMANode
+	d.systemID = des.SystemID
+	d.resourceUri = des.ResourceUri
+
+	return nil
+}
+
+func nodeDeviceSliceToInterface(in []*nodeDevice) []NodeDevice {
+	var out []NodeDevice
+	for _, d := range in {
+		out = append(out, d)
+	}
+	return out
+}
+
+func NewNodeDevicesClient(client *authenticatedClient) NodeDevices {
+	return &nodeDevices{
+		Controller: Controller{
+			client:  client,
+			apiPath: "/nodes/", // Base path, will be extended per operation
+			params:  ParamsBuilder(),
+		},
+	}
+}

--- a/maasclient/nodedevices_test.go
+++ b/maasclient/nodedevices_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2021 Spectro Cloud
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package maasclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const nodeDevicesResponse = `[
+  {
+    "id": 159,
+    "bus": 1,
+    "bus_name": "PCIE",
+    "hardware_type": 5,
+    "hardware_type_name": "gpu",
+    "vendor_id": "10de",
+    "product_id": "1eb8",
+    "vendor_name": "NVIDIA Corporation",
+    "product_name": "TU104GL [Tesla T4]",
+    "commissioning_driver": "pci",
+    "bus_number": 0,
+    "device_number": 30,
+    "pci_address": "0000:00:1e.0",
+    "numa_node": 0,
+    "physical_blockdevice": null,
+    "physical_interface": null,
+    "system_id": "abc123",
+    "resource_uri": "/MAAS/api/2.0/nodes/abc123/devices/159/"
+  },
+  {
+    "id": 42,
+    "bus": 1,
+    "bus_name": "PCIE",
+    "hardware_type": 4,
+    "hardware_type_name": "network",
+    "vendor_id": "8086",
+    "product_id": "37d2",
+    "vendor_name": "Intel Corporation",
+    "product_name": "Ethernet Connection X722",
+    "commissioning_driver": "i40e",
+    "bus_number": 0,
+    "device_number": 25,
+    "pci_address": "0000:00:19.0",
+    "numa_node": 1,
+    "physical_blockdevice": null,
+    "physical_interface": null,
+    "system_id": "abc123",
+    "resource_uri": "/MAAS/api/2.0/nodes/abc123/devices/42/"
+  }
+]`
+
+func TestNodeDevicesList(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("lists devices for a machine", func(t *testing.T) {
+		var gotMethod, gotPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, nodeDevicesResponse)
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		devices, err := c.NodeDevices().List(ctx, "abc123", nil)
+		assert.Nil(t, err)
+		assert.Equal(t, http.MethodGet, gotMethod)
+		assert.Equal(t, "/api/2.0/nodes/abc123/devices/", gotPath)
+		assert.Len(t, devices, 2)
+
+		gpu := devices[0]
+		assert.Equal(t, "159", gpu.ID())
+		assert.Equal(t, "PCIE", gpu.BusName())
+		assert.Equal(t, "gpu", gpu.HardwareTypeName())
+		assert.Equal(t, "10de", gpu.VendorID())
+		assert.Equal(t, "1eb8", gpu.ProductID())
+		assert.Equal(t, "NVIDIA Corporation", gpu.VendorName())
+		assert.Equal(t, "TU104GL [Tesla T4]", gpu.ProductName())
+		assert.Equal(t, "pci", gpu.CommissioningDriver())
+		assert.Equal(t, 0, gpu.BusNumber())
+		assert.Equal(t, 30, gpu.DeviceNumber())
+		assert.Equal(t, "0000:00:1e.0", gpu.PCIAddress())
+		assert.Equal(t, 0, gpu.NUMANode())
+		assert.Equal(t, "abc123", gpu.SystemID())
+		assert.Equal(t, "/MAAS/api/2.0/nodes/abc123/devices/159/", gpu.ResourceUri())
+
+		nic := devices[1]
+		assert.Equal(t, "42", nic.ID())
+		assert.Equal(t, "network", nic.HardwareTypeName())
+		assert.Equal(t, 1, nic.NUMANode())
+	})
+
+	t.Run("passes filter params as query string", func(t *testing.T) {
+		var gotQuery string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get(HardwareTypeKey)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "[]")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		params := ParamsBuilder().Set(HardwareTypeKey, HardwareTypeGPU)
+		devices, err := c.NodeDevices().List(ctx, "abc123", params)
+		assert.Nil(t, err)
+		assert.Equal(t, HardwareTypeGPU, gotQuery)
+		assert.Empty(t, devices)
+	})
+
+	t.Run("returns error on non-2xx response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, "Not Found")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		devices, err := c.NodeDevices().List(ctx, "missing", nil)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "status: 404")
+		assert.Nil(t, devices)
+	})
+}
+
+// TestNodeDevicesIntegration runs against a real MAAS. It follows the same
+// conventions as the other integration tests in this package: set
+// MAAS_ENDPOINT and MAAS_API_KEY, and replace the placeholder system ID.
+func TestNodeDevicesIntegration(t *testing.T) {
+	endPoint := os.Getenv("MAAS_ENDPOINT")
+	apiKey := os.Getenv("MAAS_API_KEY")
+	if endPoint == "" || apiKey == "" {
+		t.Skip("MAAS_ENDPOINT and MAAS_API_KEY must be set for integration tests")
+	}
+	c := NewAuthenticatedClientSet(endPoint, apiKey)
+
+	ctx := context.Background()
+
+	// TODO: Replace with an actual machine system ID
+	systemID := "REPLACE_WITH_MACHINE_SYSTEM_ID_1"
+	if systemID == "REPLACE_WITH_MACHINE_SYSTEM_ID_1" {
+		t.Skip("Please replace placeholder machine system ID with an actual machine")
+		return
+	}
+
+	t.Run("list all devices", func(t *testing.T) {
+		devices, err := c.NodeDevices().List(ctx, systemID, nil)
+		assert.Nil(t, err)
+		for _, d := range devices {
+			fmt.Printf("%s %s %s %s\n", d.ID(), d.HardwareTypeName(), d.VendorName(), d.ProductName())
+		}
+	})
+
+	t.Run("list gpu devices only", func(t *testing.T) {
+		params := ParamsBuilder().Set(HardwareTypeKey, HardwareTypeGPU)
+		devices, err := c.NodeDevices().List(ctx, systemID, params)
+		assert.Nil(t, err)
+		for _, d := range devices {
+			assert.Equal(t, HardwareTypeGPU, d.HardwareTypeName())
+		}
+	})
+}

--- a/maasclient/nodedevices_test.go
+++ b/maasclient/nodedevices_test.go
@@ -79,7 +79,7 @@ func TestNodeDevicesList(t *testing.T) {
 			gotMethod = r.Method
 			gotPath = r.URL.Path
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, nodeDevicesResponse)
+			_, _ = fmt.Fprint(w, nodeDevicesResponse)
 		}))
 		defer server.Close()
 
@@ -118,7 +118,7 @@ func TestNodeDevicesList(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotQuery = r.URL.Query().Get(HardwareTypeKey)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, "[]")
+			_, _ = fmt.Fprint(w, "[]")
 		}))
 		defer server.Close()
 
@@ -134,7 +134,7 @@ func TestNodeDevicesList(t *testing.T) {
 	t.Run("returns error on non-2xx response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "Not Found")
+			_, _ = fmt.Fprint(w, "Not Found")
 		}))
 		defer server.Close()
 

--- a/maasclient/oauth1/oauth1.go
+++ b/maasclient/oauth1/oauth1.go
@@ -45,7 +45,7 @@ func (auth OAuth) BuildOAuthHeader(method, path string, params map[string]string
 		vals.Add(k, v)
 	}
 	// net/url package QueryEscape escapes " " into "+", this replaces it with the percentage encoding of " "
-	parameterString := strings.Replace(vals.Encode(), "+", "%20", -1)
+	parameterString := strings.ReplaceAll(vals.Encode(), "+", "%20")
 
 	// Calculating Signature Base String and Signing Key
 	signatureBase := strings.ToUpper(method) + "&" + url.QueryEscape(strings.Split(path, "?")[0]) + "&" + url.QueryEscape(parameterString)

--- a/maasclient/subnets.go
+++ b/maasclient/subnets.go
@@ -183,4 +183,3 @@ func (s *subnets) IsIPInUse(ctx context.Context, subnetID int, ip string) (bool,
 
 	return false, nil
 }
-

--- a/maasclient/tags.go
+++ b/maasclient/tags.go
@@ -33,6 +33,9 @@ type Tags interface {
 	Create(ctx context.Context, tagName string) error
 	// Assign applies the given tag name to the provided machine system ID
 	Assign(ctx context.Context, tagName string, systemID string) error
+	// AssignToMachines applies the given tag name to multiple machine system IDs
+	// in a single request
+	AssignToMachines(ctx context.Context, tagName string, systemIDs []string) error
 	// Unassign removes the given tag name from the provided machine system ID
 	Unassign(ctx context.Context, tagName string, systemID string) error
 }
@@ -84,6 +87,27 @@ func (ds *tags) Assign(ctx context.Context, tagName string, systemID string) err
 	_, err := ds.client.Post(ctx, path, params)
 	return err
 
+}
+
+func (ds *tags) AssignToMachines(ctx context.Context, tagName string, systemIDs []string) error {
+	if tagName == "" {
+		return nil
+	}
+	params := url.Values{}
+	for _, systemID := range systemIDs {
+		if systemID != "" {
+			params.Add("add", systemID)
+		}
+	}
+	if len(params["add"]) == 0 {
+		return nil
+	}
+	path := fmt.Sprintf("%s%s/op-update_nodes", ds.apiPath, url.PathEscape(tagName))
+	res, err := ds.client.Post(ctx, path, params)
+	if err != nil {
+		return err
+	}
+	return unMarshalJson(res, nil)
 }
 
 func (ds *tags) Unassign(ctx context.Context, tagName string, systemID string) error {
@@ -156,7 +180,7 @@ func (d *tag) UnmarshalJSON(data []byte) error {
 	}
 
 	d.name = des.Name
-	d.comment = des.KernelOpts
+	d.comment = des.Comment
 	d.resource_uri = des.ResourceUri
 	d.kernel_opts = des.KernelOpts
 	d.definition = des.Definition

--- a/maasclient/tags_test.go
+++ b/maasclient/tags_test.go
@@ -29,6 +29,8 @@ package maasclient
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -105,6 +107,41 @@ func TestTags(t *testing.T) {
 		fmt.Printf("✅ Verified tag '%s' is present on machine %s\n", tagName, systemID)
 	})
 
+	t.Run("assign tag to multiple machines", func(t *testing.T) {
+		// First, create a test tag
+		tagName := "test-assign-multiple-tag"
+		err := c.Tags().Create(ctx, tagName)
+		assert.Nil(t, err, "Failed to create tag")
+
+		// TODO: Replace with actual machine system IDs you want to test with
+		// These should be unlocked machines that can have tags assigned
+		systemIDs := []string{"REPLACE_WITH_MACHINE_SYSTEM_ID_1", "REPLACE_WITH_MACHINE_SYSTEM_ID_2"}
+
+		// Skip test if placeholder values are still present
+		if systemIDs[0] == "REPLACE_WITH_MACHINE_SYSTEM_ID_1" {
+			t.Skip("Please replace placeholder machine system IDs with actual unlocked machines")
+			return
+		}
+
+		// Assign the tag to all machines in a single request
+		err = c.Tags().AssignToMachines(ctx, tagName, systemIDs)
+		assert.Nil(t, err, "Failed to assign tag to machines")
+		fmt.Printf("Successfully assigned tag '%s' to machines: %v\n", tagName, systemIDs)
+
+		// Wait a bit for the assignment to propagate
+		time.Sleep(2 * time.Second)
+
+		for _, systemID := range systemIDs {
+			machine := c.Machines().Machine(systemID)
+			detailedMachine, err := machine.Get(ctx)
+			assert.Nil(t, err, "Failed to get machine details for %s", systemID)
+			tags := detailedMachine.Tags()
+			assert.Contains(t, tags, tagName,
+				"Tag '%s' not found on machine %s. Machine tags: %v", tagName, systemID, tags)
+			fmt.Printf("✅ Verified tag '%s' is present on machine %s\n", tagName, systemID)
+		}
+	})
+
 	t.Run("unassign tag from machines", func(t *testing.T) {
 		// Create a test tag
 		tagName := "test-assign-unassign-tag"
@@ -139,4 +176,143 @@ func TestTags(t *testing.T) {
 			"Tag '%s' should not be present on machine %s after unassign. Machine tags: %v", tagName, systemID, machinetags)
 		fmt.Printf("✅ Verified tag '%s' is removed from machine %s\n", tagName, systemID)
 	})
+}
+
+func TestTagsAssignToMachines(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("posts one add value per system ID in a single request", func(t *testing.T) {
+		var gotMethod, gotPath string
+		var gotAdd []string
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			assert.Nil(t, r.ParseForm())
+			gotAdd = r.PostForm["add"]
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "{}")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "gpu-tag", []string{"abc123", "def456", "ghi789"})
+		assert.Nil(t, err)
+		assert.Equal(t, 1, requestCount)
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/2.0/tags/gpu-tag/op-update_nodes", gotPath)
+		assert.Equal(t, []string{"abc123", "def456", "ghi789"}, gotAdd)
+	})
+
+	t.Run("skips empty system IDs", func(t *testing.T) {
+		var gotAdd []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Nil(t, r.ParseForm())
+			gotAdd = r.PostForm["add"]
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "{}")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "gpu-tag", []string{"", "abc123", ""})
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"abc123"}, gotAdd)
+	})
+
+	t.Run("no-op without a request when tag name is empty", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "", []string{"abc123"})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, requestCount)
+	})
+
+	t.Run("no-op without a request when no usable system IDs", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "gpu-tag", nil)
+		assert.Nil(t, err)
+
+		err = c.Tags().AssignToMachines(ctx, "gpu-tag", []string{"", ""})
+		assert.Nil(t, err)
+
+		assert.Equal(t, 0, requestCount)
+	})
+
+	t.Run("returns error on non-2xx response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, "No Tag matches the given query.")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "missing-tag", []string{"abc123"})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "status: 404")
+	})
+
+	t.Run("escapes tag name in the path", func(t *testing.T) {
+		var gotEscapedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotEscapedPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, "{}")
+		}))
+		defer server.Close()
+
+		c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+		err := c.Tags().AssignToMachines(ctx, "gpu tag", []string{"abc123"})
+		assert.Nil(t, err)
+		assert.Equal(t, "/api/2.0/tags/gpu%20tag/op-update_nodes", gotEscapedPath)
+	})
+}
+
+// Regression test: Tag.UnmarshalJSON used to populate comment from the
+// kernel_opts field, so Comment() returned kernel options instead of the
+// tag's comment.
+func TestTagsList_UnmarshalsComment(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[
+		  {
+		    "name": "gpu",
+		    "definition": "//node[@class=\"display\"]",
+		    "comment": "machines with GPUs",
+		    "kernel_opts": "console=tty0",
+		    "resource_uri": "/MAAS/api/2.0/tags/gpu/"
+		  }
+		]`)
+	}))
+	defer server.Close()
+
+	c := NewAuthenticatedClientSet(server.URL, "consumer:token:secret")
+
+	tags, err := c.Tags().List(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, tags, 1)
+	assert.Equal(t, "gpu", tags[0].Name())
+	assert.Equal(t, "machines with GPUs", tags[0].Comment())
+	assert.Equal(t, "console=tty0", tags[0].KernelOpts())
+	assert.Equal(t, `//node[@class="display"]`, tags[0].Definition())
 }

--- a/maasclient/tags_test.go
+++ b/maasclient/tags_test.go
@@ -192,7 +192,7 @@ func TestTagsAssignToMachines(t *testing.T) {
 			assert.Nil(t, r.ParseForm())
 			gotAdd = r.PostForm["add"]
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, "{}")
+			_, _ = fmt.Fprint(w, "{}")
 		}))
 		defer server.Close()
 
@@ -212,7 +212,7 @@ func TestTagsAssignToMachines(t *testing.T) {
 			assert.Nil(t, r.ParseForm())
 			gotAdd = r.PostForm["add"]
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, "{}")
+			_, _ = fmt.Fprint(w, "{}")
 		}))
 		defer server.Close()
 
@@ -258,7 +258,7 @@ func TestTagsAssignToMachines(t *testing.T) {
 	t.Run("returns error on non-2xx response", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "No Tag matches the given query.")
+			_, _ = fmt.Fprint(w, "No Tag matches the given query.")
 		}))
 		defer server.Close()
 
@@ -274,7 +274,7 @@ func TestTagsAssignToMachines(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotEscapedPath = r.URL.EscapedPath()
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, "{}")
+			_, _ = fmt.Fprint(w, "{}")
 		}))
 		defer server.Close()
 
@@ -294,7 +294,7 @@ func TestTagsList_UnmarshalsComment(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `[
+		_, _ = fmt.Fprint(w, `[
 		  {
 		    "name": "gpu",
 		    "definition": "//node[@class=\"display\"]",

--- a/maasclient/user_test.go
+++ b/maasclient/user_test.go
@@ -18,9 +18,10 @@ package maasclient
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUsers(t *testing.T) {
@@ -40,7 +41,7 @@ func TestUsers(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, res)
 		assert.NotEmpty(t, res)
-		assert.Equal(t, res.UserName(), "dev")
+		assert.NotEqual(t, "", res.UserName()) // actual userName changes depending on api key
 	})
 
 }

--- a/maasclient/vmhosts_test.go
+++ b/maasclient/vmhosts_test.go
@@ -32,13 +32,13 @@ func TestVMHost_Tags(t *testing.T) {
 	t.Run("list vmhosts and verify tags field", func(t *testing.T) {
 		hosts, err := c.VMHosts().List(ctx, nil)
 		assert.Nil(t, err)
-		assert.NotNil(t, hosts)
 
 		if len(hosts) == 0 {
 			t.Skip("No VM hosts available to test")
 		}
 
 		// Verify Tags() returns a slice (not nil) for each host
+		assert.NotNil(t, hosts)
 		for _, host := range hosts {
 			tagsTest := host.Tags()
 			assert.NotNil(t, tagsTest, "Tags() should return empty slice, not nil for host %s", host.Name())


### PR DESCRIPTION
- Adds methods for listing node_devices and adding a tag to multiple machines
- Adds accessors for additional machine fields that were already returned by the API
- Updates tests so that they can be run against different MAAS environments; replaces hardcoded expected values with env vars
- Resolves existing linter errors
- Fixes a bug in ListMachines where params were previously dropped

Important note:

Since the interface changes, `cluster-api-provider-maas`'s generated mocks will fail to compile on the next version bump. To resolve, re-run mockgen when upgrading the package version.